### PR TITLE
Quick fix for link on forcats README pages

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -31,7 +31,7 @@ However, factors are still useful when you have true categorical data, and when 
 install.packages("tidyverse")
 
 # Alternatively, install just forcats:
-install.packages("readr")
+install.packages("forcats")
 
 # Or the the development version from GitHub:
 # install.packages("devtools")

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Installation
 install.packages("tidyverse")
 
 # Alternatively, install just forcats:
-install.packages("readr")
+install.packages("forcats")
 
 # Or the the development version from GitHub:
 # install.packages("devtools")


### PR DESCRIPTION
(I could also be wrong. Maybe `forcats` needs `readr`.)