### PR TITLE
document the use of ‘Inf’ to relevel to the end

### DIFF
--- a/R/relevel.R
+++ b/R/relevel.R
@@ -1,24 +1,33 @@
 #' Reorder factor levels by hand
 #'
-#' This is a generalisaton of [stats::relevel()] that allows you to
-#' move any number of levels to any location.
+#' This is a generalisaton of [stats::relevel()] that allows you to move any
+#' number of levels to any location.
 #'
 #' @param f A factor.
-#' @param ... Character vector of levels. Any levels not mentioned will be
-#'   left in existing order, after the explicitly mentioned levels.
+#' @param ... Character vector of levels. Any levels not mentioned will be left
+#'   in existing order, after the explicitly mentioned levels.
 #' @param after Where should the new values be placed?
 #' @export
 #' @examples
-#' f <- factor(c("a", "b", "c"))
+#' f <- factor(c("a", "b", "c", "d"))
 #' fct_relevel(f)
 #' fct_relevel(f, "c")
 #' fct_relevel(f, "b", "a")
 #'
-#' # Move to end
+#' # Move to the third position
 #' fct_relevel(f, "a", after = 2)
 #'
+#' # Relevel to the end
+#' fct_relevel(f, "a", after = Inf)
+#' fct_relevel(f, "a", after = 3)
+#'
+#' # Using 'Inf' instead of an integer is useful when the number
+#' # of levels is unknown, or in a vectorised operation
+#' x <- list(f, factor(c("y", "a", "z")))
+#' lapply(x, fct_relevel, "a", after = Inf)
+#'
 #' # You'll get a warning if the levels don't exist
-#' fct_relevel(f, "d")
+#' fct_relevel(f, "e")
 fct_relevel <- function(f, ..., after = 0L) {
   f <- check_factor(f)
 

--- a/man/fct_relevel.Rd
+++ b/man/fct_relevel.Rd
@@ -9,24 +9,34 @@ fct_relevel(f, ..., after = 0L)
 \arguments{
 \item{f}{A factor.}
 
-\item{...}{Character vector of levels. Any levels not mentioned will be
-left in existing order, after the explicitly mentioned levels.}
+\item{...}{Character vector of levels. Any levels not mentioned will be left
+in existing order, after the explicitly mentioned levels.}
 
 \item{after}{Where should the new values be placed?}
 }
 \description{
-This is a generalisaton of \code{\link[stats:relevel]{stats::relevel()}} that allows you to
-move any number of levels to any location.
+This is a generalisaton of [stats::relevel()] that allows you to move any
+number of levels to any location.
 }
 \examples{
-f <- factor(c("a", "b", "c"))
+f <- factor(c("a", "b", "c", "d"))
 fct_relevel(f)
 fct_relevel(f, "c")
 fct_relevel(f, "b", "a")
 
-# Move to end
+# Move to the third position
 fct_relevel(f, "a", after = 2)
 
+# Relevel to the end
+fct_relevel(f, "a", after = Inf)
+fct_relevel(f, "a", after = 3)
+
+# Using 'Inf' instead of an integer is useful when the number
+# of levels is unknown, or in a vectorised operation
+x <- list(f, factor(c("y", "a", "z")))
+lapply(x, fct_relevel, "a", after = Inf)
+
 # You'll get a warning if the levels don't exist
-fct_relevel(f, "d")
+fct_relevel(f, "e")
 }
+

--- a/tests/testthat/test-fct_relevel.R
+++ b/tests/testthat/test-fct_relevel.R
@@ -18,5 +18,7 @@ test_that("can moves supplied levels to end", {
   f1 <- factor(c("a", "b", "c", "d"))
 
   f2 <- fct_relevel(f1, "a", "b", after = 2)
+  f3 <- fct_relevel(f1, "a", "b", after = Inf)
   expect_equal(levels(f2), c("c", "d", "a", "b"))
+  expect_equal(levels(f3), c("c", "d", "a", "b"))
 })


### PR DESCRIPTION
This PR adds documentation and tests for the `fct_relevel` function using the argument `after = Inf`.