### PR TITLE
Allow fct_recode to take arguments as list

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -19,7 +19,7 @@ Imports:
     tibble,
     magrittr
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 5.0.1.9000
+RoxygenNote: 6.0.1
 Suggests:
     ggplot2,
     testthat,

--- a/R/recode.R
+++ b/R/recode.R
@@ -1,6 +1,8 @@
 #' Change factor levels by hand
 #'
 #' @param f A factor.
+#' @param .levels A list of named character vectors where the
+#'.  name gives the new level and the value gives the old level.
 #' @param ... A sequence of named character vectors where the
 #'   name gives the new level, and the value gives the old level.
 #'   Levels not otherwise mentioned will be left as is. Levels can
@@ -9,6 +11,9 @@
 #' @examples
 #' x <- factor(c("apple", "bear", "banana", "dear"))
 #' fct_recode(x, fruit = "apple", fruit = "banana")
+#' 
+#' recoding <- list(fruit="apple", fruit="banana")
+#' fct_recode(x, recoding)
 #'
 #' # If you make a mistake you'll get a warning
 #' fct_recode(x, fruit = "apple", fruit = "bananana")

--- a/R/recode.R
+++ b/R/recode.R
@@ -15,10 +15,16 @@
 #'
 #' # If you name the level NULL it will be removed
 #' fct_recode(x, NULL = "apple", fruit = "banana")
-fct_recode <- function(f, ...) {
+fct_recode <- function(f, .levels, ...) {
   f <- check_factor(f)
 
-  new_levels <- check_recode_levels(...)
+  if (missing(.levels)) {
+    .levels = list(...)
+  } else {
+    .levels <- c(.levels, list(...))
+  }
+  
+  new_levels <- check_recode_levels(.levels)
 
   # Remove any named NULL and finish if all NULLs
   nulls <- names(new_levels) == "NULL"
@@ -45,8 +51,7 @@ fct_recode <- function(f, ...) {
   lvls_revalue(f, old_levels)
 }
 
-check_recode_levels <- function(...) {
-  levels <- list(...)
+check_recode_levels <- function(levels) {
 
   is_ok <- function(x) is.character(x) && length(x) == 1
   ok <- vapply(levels, is_ok, logical(1))

--- a/man/fct_recode.Rd
+++ b/man/fct_recode.Rd
@@ -4,10 +4,13 @@
 \alias{fct_recode}
 \title{Change factor levels by hand}
 \usage{
-fct_recode(f, ...)
+fct_recode(f, .levels, ...)
 }
 \arguments{
 \item{f}{A factor.}
+
+\item{.levels}{A list of named character vectors where the
+.  name gives the new level and the value gives the old level.}
 
 \item{...}{A sequence of named character vectors where the
 name gives the new level, and the value gives the old level.
@@ -20,6 +23,9 @@ Change factor levels by hand
 \examples{
 x <- factor(c("apple", "bear", "banana", "dear"))
 fct_recode(x, fruit = "apple", fruit = "banana")
+
+recoding <- list(fruit="apple", fruit="banana")
+fct_recode(x, recoding)
 
 # If you make a mistake you'll get a warning
 fct_recode(x, fruit = "apple", fruit = "bananana")

--- a/tests/testthat/test-fct_recode.R
+++ b/tests/testthat/test-fct_recode.R
@@ -28,6 +28,13 @@ test_that("can just remove levels", {
   expect_equal(fct_recode(f1, NULL = "missing"), f2)
 })
 
+test_that("can pass arguments as list", {
+  f1 <- factor(c("a", "b", "c"))
+  f2 <- factor(c("y", "y", "z"))
+  args <- list(y="a", y="b")
+  
+  expect_equal(fct_recode(f1, args, z="c"))
+})
 
 # check_recode_levels -----------------------------------------------------
 

--- a/tests/testthat/test-fct_recode.R
+++ b/tests/testthat/test-fct_recode.R
@@ -33,15 +33,15 @@ test_that("can pass arguments as list", {
   f2 <- factor(c("y", "y", "z"))
   args <- list(y="a", y="b")
   
-  expect_equal(fct_recode(f1, args, z="c"))
+  expect_equal(fct_recode(f1, args, z="c"), f2)
 })
 
 # check_recode_levels -----------------------------------------------------
 
 test_that("new levels must be character", {
-  expect_error(check_recode_levels(a = 1), "Problems at positions: 1")
+  expect_error(check_recode_levels(list(a = 1)), "Problems at positions: 1")
 })
 
 test_that("new levels must be length 1", {
-  expect_error(check_recode_levels(a = c("a", "b")), "Problems at positions: 1")
+  expect_error(check_recode_levels(list(a = c("a", "b"))), "Problems at positions: 1")
 })


### PR DESCRIPTION
Hi Hadley, 

### Issue:
When calling `fct_recode`, I would like to be able to specify a list of recodings like so:
```r
recodings = list(x="a", y="b")
fct_recode(f, recodings)
```
However, this gives an error because check_factor_levels converts the list to a list-of-a-list, which breaks the `is_ok` check:
```r
check_recode_levels <- function(...) {
  levels <- list(...)

  is_ok <- function(x) is.character(x) && length(x) == 1
  ok <- vapply(levels, is_ok, logical(1))
  # [... truncated]
```

Right now, to get around this, I have to call do.call on fct_recode like so:
```r
f = do.call(function(...) fct_recode(f, ...), recodings)
```

### This pull request
I've modified `fct_recode` so that it optionally takes a named argument `.levels`. The old behavior is maintained - `fct_recode(f, x='a', y='b')` - but we can also do `fct_recode(f, recodings)` and also mix behaviors: `fct_recode(f, recodings, z='c')`

This should also provide a fix for #84 if the author wraps their argument in a list.

I have written a test for this behavior and modified the two `check_recode_levels` tests to be compatible. 