### PR TITLE
Allow NA in fct_inorder()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # forcats 0.2.0.9000
 
+* `as_factor()` and `fct_inorder()` accept NA levels (#98).
+
 # forcats 0.2.0
 
 ## New functions

--- a/R/reorder.R
+++ b/R/reorder.R
@@ -82,7 +82,9 @@ last2 <- function(x, y) {
 fct_inorder <- function(f, ordered = NA) {
   f <- check_factor(f)
 
-  lvls_reorder(f, as.integer(f)[!duplicated(f)], ordered = ordered)
+  idx <- as.integer(f)[!duplicated(f)]
+  idx <- idx[!is.na(idx)]
+  lvls_reorder(f, idx, ordered = ordered)
 }
 
 #' @export

--- a/tests/testthat/test-as_factor.R
+++ b/tests/testthat/test-as_factor.R
@@ -4,3 +4,8 @@ test_that("equivalent to fct_inorder", {
   x <- c("a", "z", "g")
   expect_equal(as_factor(x), fct_inorder(x))
 })
+
+test_that("supports NA (#89)", {
+  x <- c("a", "z", "g", NA)
+  expect_equal(as_factor(x), fct_inorder(x))
+})


### PR DESCRIPTION
and `as_factor()`. Closes #89.