### PR TITLE
add '(or character vector)' to function argument descriptions where a…

### DIFF
--- a/R/collapse.R
+++ b/R/collapse.R
@@ -1,6 +1,6 @@
 #' Collapse factor levels into manually defined groups
 #'
-#' @param f A factor.
+#' @param f A factor (or character vector).
 #' @param ... A series of named character vectors. The levels in
 #'   each vector will be replaced with the name.
 #' @export

--- a/R/count.R
+++ b/R/count.R
@@ -1,6 +1,6 @@
 #' Count entries in a factor
 #'
-#' @param f A factor.
+#' @param f A factor (or character vector).
 #' @param sort If `TRUE`, sort the result so that the most common values
 #'   float to the top.
 #' @return A tibble with columns `f` and `n`.

--- a/R/drop.R
+++ b/R/drop.R
@@ -2,7 +2,7 @@
 #'
 #' Compared to `base::droplevels()`, does not drop `NA` levels that have values.
 #'
-#' @param f A factor.
+#' @param f A factor (or character vector).
 #' @param only A character vector restricting the set of levels to be dropped.
 #'   If supplied, only levels that have no entries and appear in this vector
 #'   will be removed.

--- a/R/expand.R
+++ b/R/expand.R
@@ -1,6 +1,6 @@
 #' Add additional levels to a factor
 #'
-#' @param f A factor.
+#' @param f A factor (or character vector).
 #' @param ... Additional levels to add to the factor.  Levels that already
 #'    exist will be silently ignored.
 #' @export

--- a/R/explicit_na.R
+++ b/R/explicit_na.R
@@ -3,7 +3,7 @@
 #' This gives missing value an explicit factor level, ensuring that they
 #' appear in summaries and on plots.
 #'
-#' @param f A factor.
+#' @param f A factor (or character vector).
 #' @param na_level Level to use for missing values.
 #' @export
 #' @examples

--- a/R/lump.R
+++ b/R/lump.R
@@ -1,6 +1,6 @@
 #' Lump together least/most common factor levels into "other"
 #'
-#' @param f A factor.
+#' @param f A factor (or character vector).
 #' @param n,prop
 #'   If both `n` and `prop` are missing, `fct_lump` lumps
 #'   together the least frequent levels into "other", while ensuring that

--- a/R/recode.R
+++ b/R/recode.R
@@ -1,6 +1,6 @@
 #' Change factor levels by hand
 #'
-#' @param f A factor.
+#' @param f A factor (or character vector).
 #' @param ... A sequence of named character vectors where the
 #'   name gives the new level, and the value gives the old level.
 #'   Levels not otherwise mentioned will be left as is. Levels can

--- a/R/relevel.R
+++ b/R/relevel.R
@@ -3,7 +3,7 @@
 #' This is a generalisaton of [stats::relevel()] that allows you to move any
 #' number of levels to any location.
 #'
-#' @param f A factor.
+#' @param f A factor (or character vector).
 #' @param ... Character vector of levels. Any levels not mentioned will be left
 #'   in existing order, after the explicitly mentioned levels.
 #' @param after Where should the new values be placed?

--- a/R/reorder.R
+++ b/R/reorder.R
@@ -5,7 +5,7 @@
 #' a non-position aesthetic. `last2()` is a helper for `fct_reorder2()`;
 #' it finds the last value of `y` when sorted by `x`.
 #'
-#' @param f A factor.
+#' @param f A factor (or character vector).
 #' @param x,y The levels of `f` are reordered so that the values
 #'    of `fun(x)` (for `fct_reorder()`) and `fun(x, y)` (for `fct_reorder2()`)
 #'    are in ascending order.

--- a/R/rev.R
+++ b/R/rev.R
@@ -2,7 +2,7 @@
 #'
 #' This is sometimes useful when plotting a factor.
 #'
-#' @param f A factor.
+#' @param f A factor (or character vector).
 #' @export
 #' @examples
 #' f <- factor(c("a", "b", "c"))

--- a/R/shuffle.R
+++ b/R/shuffle.R
@@ -1,6 +1,6 @@
 #' Randomly permute factor levels
 #'
-#' @param f A factor.
+#' @param f A factor (or character vector).
 #' @export
 #' @examples
 #' f <- factor(c("a", "b", "c"))

--- a/man/fct_collapse.Rd
+++ b/man/fct_collapse.Rd
@@ -7,7 +7,7 @@
 fct_collapse(f, ...)
 }
 \arguments{
-\item{f}{A factor.}
+\item{f}{A factor (or character vector).}
 
 \item{...}{A series of named character vectors. The levels in
 each vector will be replaced with the name.}

--- a/man/fct_count.Rd
+++ b/man/fct_count.Rd
@@ -7,7 +7,7 @@
 fct_count(f, sort = FALSE)
 }
 \arguments{
-\item{f}{A factor.}
+\item{f}{A factor (or character vector).}
 
 \item{sort}{If \code{TRUE}, sort the result so that the most common values
 float to the top.}

--- a/man/fct_drop.Rd
+++ b/man/fct_drop.Rd
@@ -7,7 +7,7 @@
 fct_drop(f, only)
 }
 \arguments{
-\item{f}{A factor.}
+\item{f}{A factor (or character vector).}
 
 \item{only}{A character vector restricting the set of levels to be dropped.
 If supplied, only levels that have no entries and appear in this vector

--- a/man/fct_expand.Rd
+++ b/man/fct_expand.Rd
@@ -7,7 +7,7 @@
 fct_expand(f, ...)
 }
 \arguments{
-\item{f}{A factor.}
+\item{f}{A factor (or character vector).}
 
 \item{...}{Additional levels to add to the factor.  Levels that already
 exist will be silently ignored.}

--- a/man/fct_explicit_na.Rd
+++ b/man/fct_explicit_na.Rd
@@ -7,7 +7,7 @@
 fct_explicit_na(f, na_level = "(Missing)")
 }
 \arguments{
-\item{f}{A factor.}
+\item{f}{A factor (or character vector).}
 
 \item{na_level}{Level to use for missing values.}
 }

--- a/man/fct_lump.Rd
+++ b/man/fct_lump.Rd
@@ -8,7 +8,7 @@ fct_lump(f, n, prop, w = NULL, other_level = "Other",
   ties.method = c("min", "average", "first", "last", "random", "max"))
 }
 \arguments{
-\item{f}{A factor.}
+\item{f}{A factor (or character vector).}
 
 \item{n, prop}{If both \code{n} and \code{prop} are missing, \code{fct_lump} lumps
 together the least frequent levels into "other", while ensuring that

--- a/man/fct_other.Rd
+++ b/man/fct_other.Rd
@@ -7,7 +7,7 @@
 fct_other(f, keep, drop, other_level = "Other")
 }
 \arguments{
-\item{f}{A factor.}
+\item{f}{A factor (or character vector).}
 
 \item{keep, drop}{\code{keep} will preserve listed levels, replacing all others
 with \code{other_level}. \code{drop} will replace listed levels with \code{other_level},

--- a/man/fct_recode.Rd
+++ b/man/fct_recode.Rd
@@ -7,7 +7,7 @@
 fct_recode(f, ...)
 }
 \arguments{
-\item{f}{A factor.}
+\item{f}{A factor (or character vector).}
 
 \item{...}{A sequence of named character vectors where the
 name gives the new level, and the value gives the old level.

--- a/man/fct_relevel.Rd
+++ b/man/fct_relevel.Rd
@@ -7,7 +7,7 @@
 fct_relevel(f, ..., after = 0L)
 }
 \arguments{
-\item{f}{A factor.}
+\item{f}{A factor (or character vector).}
 
 \item{...}{Character vector of levels. Any levels not mentioned will be left
 in existing order, after the explicitly mentioned levels.}

--- a/man/fct_reorder.Rd
+++ b/man/fct_reorder.Rd
@@ -13,7 +13,7 @@ fct_reorder2(f, x, y, fun = last2, ..., .desc = TRUE)
 last2(x, y)
 }
 \arguments{
-\item{f}{A factor.}
+\item{f}{A factor (or character vector).}
 
 \item{x, y}{The levels of \code{f} are reordered so that the values
 of \code{fun(x)} (for \code{fct_reorder()}) and \code{fun(x, y)} (for \code{fct_reorder2()})

--- a/man/fct_rev.Rd
+++ b/man/fct_rev.Rd
@@ -7,7 +7,7 @@
 fct_rev(f)
 }
 \arguments{
-\item{f}{A factor.}
+\item{f}{A factor (or character vector).}
 }
 \description{
 This is sometimes useful when plotting a factor.

--- a/man/fct_shuffle.Rd
+++ b/man/fct_shuffle.Rd
@@ -7,7 +7,7 @@
 fct_shuffle(f)
 }
 \arguments{
-\item{f}{A factor.}
+\item{f}{A factor (or character vector).}
 }
 \description{
 Randomly permute factor levels


### PR DESCRIPTION
Fixes #102. I went through and verified which functions can accept a character vector. `lvls_reorder` and `lvls_revalue` both can because of `check_factor`, but `lvls_expands` cannot, so I kept the `lvls` documentation as accepting only a factor. 