### PR TITLE
Add cross-refs for `fct_drop()` and `fct_expand()`

### DIFF
--- a/R/drop.R
+++ b/R/drop.R
@@ -7,6 +7,7 @@
 #'   If supplied, only levels that have no entries and appear in this vector
 #'   will be removed.
 #' @export
+#' @seealso [fct_expand()] to add additional levels to a factor.
 #' @examples
 #' f <- factor(c("a", "b"), levels = c("a", "b", "c"))
 #' f

--- a/R/expand.R
+++ b/R/expand.R
@@ -4,6 +4,7 @@
 #' @param ... Additional levels to add to the factor.  Levels that already
 #'    exist will be silently ignored.
 #' @export
+#' @seealso [fct_drop()] to drop unused factor levels.
 #' @examples
 #' f <- factor(sample(letters[1:3], 20, replace = TRUE))
 #' f

--- a/man/fct_drop.Rd
+++ b/man/fct_drop.Rd
@@ -25,3 +25,6 @@ fct_drop(f)
 fct_drop(f, only = "a")
 fct_drop(f, only = "c")
 }
+\seealso{
+\code{\link[=fct_expand]{fct_expand()}} to add additional levels to a factor.
+}

--- a/man/fct_expand.Rd
+++ b/man/fct_expand.Rd
@@ -21,3 +21,6 @@ f
 fct_expand(f, "d", "e", "f")
 fct_expand(f, letters[1:6])
 }
+\seealso{
+\code{\link[=fct_drop]{fct_drop()}} to drop unused factor levels.
+}


### PR DESCRIPTION
* Fixes #137 
* Add `@seealso` notes in `fct_drop()` and `fct_expand()` for ~inverse operations.