### PR TITLE
fct_relabel accepts character input

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # forcats 0.3.0.9000
 
+* `fct_relabel()` now accepts character input.
+
 # forcats 0.3.0
 
 ## API changes

--- a/R/relabel.R
+++ b/R/relabel.R
@@ -1,6 +1,6 @@
 #' Automatically relabel factor levels, collapse as necessary
 #'
-#' @param .f A factor.
+#' @param .f A factor (or character vector).
 #' @param .fun A function to be applied to each level. Must accept one
 #'   character argument and return a character vector of the same length as
 #'   its input.
@@ -26,10 +26,11 @@
 #' rincome2 <- fct_relabel(gss_cat$rincome, convert_income)
 #' fct_count(rincome2)
 fct_relabel <- function(.f, .fun, ...) {
+  f <- check_factor(.f)
   .fun <- rlang::as_function(.fun)
 
-  old_levels <- levels(.f)
+  old_levels <- levels(f)
   new_levels <- .fun(old_levels, ...)
 
-  lvls_revalue(.f, new_levels)
+  lvls_revalue(f, new_levels)
 }

--- a/man/fct_relabel.Rd
+++ b/man/fct_relabel.Rd
@@ -7,7 +7,7 @@
 fct_relabel(.f, .fun, ...)
 }
 \arguments{
-\item{.f}{A factor.}
+\item{.f}{A factor (or character vector).}
 
 \item{.fun}{A function to be applied to each level. Must accept one
 character argument and return a character vector of the same length as

--- a/tests/testthat/test-fct_relabel.R
+++ b/tests/testthat/test-fct_relabel.R
@@ -45,3 +45,10 @@ test_that("formulas are coerced to functions", {
     factor(paste0(letters, "."))
   )
 })
+
+test_that("string input is coerced to a factor", {
+  expect_identical(
+    fct_relabel(LETTERS[1:2], .fun=function(x) x),
+    factor(LETTERS[1:2])
+  )
+})


### PR DESCRIPTION
This PR makes `fct_relabel()` have parallel functionality with respect to character input as other `fct_*()` functions.