### PR TITLE
Add group_other option to fct_collapse, to allow for optional recoding of all non-targeted levels into an "Other" category

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,8 @@
 # forcats 0.3.0.9000
 
 * `fct_relabel()` now accepts character input.
+* `fct_collapse()` gains a `group_other` argument to allow you to group all 
+  un-named levels into `"Other"`. (#100, @AmeliaMN)
 
 # forcats 0.3.0
 

--- a/R/collapse.R
+++ b/R/collapse.R
@@ -3,7 +3,7 @@
 #' @param .f A factor (or character vector).
 #' @param ... A series of named character vectors. The levels in
 #'   each vector will be replaced with the name.
-#' @param group_other Replace all levels not named in `...` to "Other"?
+#' @param group_other Replace all levels not named in `...` with "Other"?
 #' @export
 #' @examples
 #' fct_count(gss_cat$partyid)

--- a/R/collapse.R
+++ b/R/collapse.R
@@ -3,6 +3,7 @@
 #' @param .f A factor (or character vector).
 #' @param ... A series of named character vectors. The levels in
 #'   each vector will be replaced with the name.
+#' @param group_other Replace all levels not named in `...` to "Other"?
 #' @export
 #' @examples
 #' fct_count(gss_cat$partyid)
@@ -15,10 +16,16 @@
 #'   dem = c("Not str democrat", "Strong democrat")
 #' )
 #' fct_count(partyid2)
-fct_collapse <- function(.f, ...) {
+fct_collapse <- function(.f, ..., group_other = FALSE) {
   new <- rlang::dots_list(...)
-
   levs <- as.list(unlist(new, use.names = FALSE))
+  if(group_other){
+    f <- check_factor(.f)
+    levels <- levels(f)
+    new[["Other"]] <- levels[!levels %in% levs]
+    levs <- levels
+  }
+
   names(levs) <- names(new)[rep(seq_along(new), vapply(new, length, integer(1)))]
 
   fct_recode(.f, !!!levs)

--- a/R/collapse.R
+++ b/R/collapse.R
@@ -19,7 +19,7 @@
 fct_collapse <- function(.f, ..., group_other = FALSE) {
   new <- rlang::dots_list(...)
   levs <- as.list(unlist(new, use.names = FALSE))
-  if(group_other){
+  if (group_other){
     f <- check_factor(.f)
     levels <- levels(f)
     new[["Other"]] <- levels[!levels %in% levs]

--- a/man/fct_collapse.Rd
+++ b/man/fct_collapse.Rd
@@ -4,13 +4,15 @@
 \alias{fct_collapse}
 \title{Collapse factor levels into manually defined groups}
 \usage{
-fct_collapse(.f, ...)
+fct_collapse(.f, ..., group_other = FALSE)
 }
 \arguments{
 \item{.f}{A factor (or character vector).}
 
 \item{...}{A series of named character vectors. The levels in
 each vector will be replaced with the name.}
+
+\item{group_other}{Replace all levels not named in \code{...} to "Other"?}
 }
 \description{
 Collapse factor levels into manually defined groups

--- a/man/forcats-package.Rd
+++ b/man/forcats-package.Rd
@@ -8,10 +8,11 @@
 \description{
 \if{html}{\figure{logo.png}{options: align='right'}}
 
-Helpers for reordering factor levels (including moving
-    specified levels to front, ordering by first appearance, reversing, and
-    randomly shuffling), and tools for modifying factor levels (including
-    collapsing rare levels into other, 'anonymising', and manually 'recoding').
+Helpers for reordering factor levels (including
+    moving specified levels to front, ordering by first appearance,
+    reversing, and randomly shuffling), and tools for modifying factor
+    levels (including collapsing rare levels into other, 'anonymising',
+    and manually 'recoding').
 }
 \seealso{
 Useful links:

--- a/tests/testthat/test-collapse.R
+++ b/tests/testthat/test-collapse.R
@@ -24,14 +24,14 @@ test_that("can collapse missing levels", {
 
 test_that("can collapse un-named levels to Other", {
   f1 <- factor(letters[1:3])
-  f2 <- fct_collapse(f1, xy = c("a", "b"), group_other=TRUE)
+  f2 <- fct_collapse(f1, xy = c("a", "b"), group_other = TRUE)
 
-  expect_equal(f2, factor(c("xy", "xy", "Other"), levels=c("xy", "Other")))
+  expect_equal(f2, factor(c("xy", "xy", "Other"), levels = c("xy", "Other")))
 })
 
 test_that("does not automatically collapse unnamed levels to Other", {
   f1 <- factor(letters[1:3])
   f2 <- fct_collapse(f1, xy = c("a", "b"))
 
-  expect_equal(f2, factor(c("xy", "xy", "c"), levels=c("xy", "c")))
+  expect_equal(f2, factor(c("xy", "xy", "c"), levels = c("xy", "c")))
 })

--- a/tests/testthat/test-collapse.R
+++ b/tests/testthat/test-collapse.R
@@ -21,3 +21,17 @@ test_that("can collapse missing levels", {
 
   expect_equal(f2, factor(c("x", "y")))
 })
+
+test_that("can collapse un-named levels to Other", {
+  f1 <- factor(letters[1:3])
+  f2 <- fct_collapse(f1, xy = c("a", "b"), group_other=TRUE)
+
+  expect_equal(f2, factor(c("xy", "xy", "Other"), levels=c("xy", "Other")))
+})
+
+test_that("does not automatically collapse unnamed levels to Other", {
+  f1 <- factor(letters[1:3])
+  f2 <- fct_collapse(f1, xy = c("a", "b"))
+
+  expect_equal(f2, factor(c("xy", "xy", "c"), levels=c("xy", "c")))
+})


### PR DESCRIPTION
Fixes #100 