### PR TITLE
fix for issue whereby fct_collapse mislabels collapsed factors, where… (Fix #172)

### DIFF
--- a/R/collapse.R
+++ b/R/collapse.R
@@ -23,7 +23,7 @@ fct_collapse <- function(.f, ..., group_other = FALSE) {
     f <- check_factor(.f)
     levels <- levels(f)
     new[["Other"]] <- levels[!levels %in% levs]
-    levs <- levels
+    levs <- unlist(new, use.names = F)
   }
 
   names(levs) <- names(new)[rep(seq_along(new), vapply(new, length, integer(1)))]


### PR DESCRIPTION
… input column is a character vector, and `group_other` = TRUE

See output following fix:

```
gss_cat2 <-
  gss_cat %>%
  mutate(partyid = as.character(partyid)) %>% 
  mutate(partyid2 = fct_collapse(partyid,
                                    missing = c("No answer", "Don't know"),
                                    other = "Other party",
                                    rep = c("Strong republican", "Not str republican"),
                                    ind = c("Ind,near rep", "Independent", "Ind,near dem"),
                                    dem = c("Not str democrat", "Strong democrat"), group_other = TRUE
  ))

gss_cat2 %>% 
  distinct(partyid2, partyid)

# A tibble: 10 x 2
   partyid            partyid2
   <chr>              <fct>   
 1 Ind,near rep       ind     
 2 Not str republican rep     
 3 Independent        ind     
 4 Not str democrat   dem     
 5 Strong democrat    dem     
 6 Ind,near dem       ind     
 7 Strong republican  rep     
 8 Other party        other   
 9 No answer          missing 
10 Don't know         missing 
```