### PR TITLE
as_factor() example for numeric-method object

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,10 @@
 
 * `first2()`, a `fct_reorder2()` helper function, sorts `.y` by the first value of `.x` (@jtr13).
 
+## Minor bug fixes and improvements
+
+* Added numeric-method example to `as_factor()` (@sinarueeger, #198).
+
 # forcats 0.4.0
 
 ## New features

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,10 +2,6 @@
 
 * `first2()`, a `fct_reorder2()` helper function, sorts `.y` by the first value of `.x` (@jtr13).
 
-## Minor bug fixes and improvements
-
-* Added numeric-method example to `as_factor()` (@sinarueeger, #198).
-
 # forcats 0.4.0
 
 ## New features

--- a/R/as_factor.R
+++ b/R/as_factor.R
@@ -1,9 +1,9 @@
 #' Convert input to a factor.
 #'
-#' Compared to base R, when \code{x} is a character, this function creates
+#' Compared to base R, when `x` is a character, this function creates
 #' levels in the order in which they appear, which will be the same on every
 #' platform. (Base R sorts in the current locale which can vary from place
-#' to place.) When \code{x} is numeric, the ordering is based on the numeric
+#' to place.) When `x` is numeric, the ordering is based on the numeric
 #' value and consistent with base R.
 #'
 #' This is a generic function.
@@ -12,18 +12,17 @@
 #' @param ... Other arguments passed down to method.
 #' @export
 #' @examples
-#'
-#' ## Character object
+#' # Character object
 #' x <- c("a", "z", "g")
 #' as_factor(x)
 #' as.factor(x)
 #'
-#' ## Character object containing numbers
+#' # Character object containing numbers
 #' y <- c("1.1", "11", "2.2", "22")
 #' as_factor(y)
 #' as.factor(y)
 #'
-#' ## Numeric object
+#' # Numeric object
 #' z <- as.numeric(y)
 #' as_factor(z)
 #' as.factor(z)

--- a/R/as_factor.R
+++ b/R/as_factor.R
@@ -22,7 +22,7 @@
 #' as.factor(y)
 #'
 #' ## Numeric vector
-#' z <- c(1.1, 11, 2.2, 22)
+#' z <- as_numeric(y)
 #' as_factor(z)
 #' as.factor(z)
 as_factor <- function(x, ...) {

--- a/R/as_factor.R
+++ b/R/as_factor.R
@@ -16,6 +16,9 @@
 #' y <- c("1.1", "11", "2.2", "22")
 #' as_factor(y)
 #' as.factor(y)
+#' z <- c(1.1, 11, 2.2, 22)
+#' as_factor(z)
+#' as.factor(z)
 as_factor <- function(x, ...) {
   ellipsis::check_dots_used()
   UseMethod("as_factor")

--- a/R/as_factor.R
+++ b/R/as_factor.R
@@ -10,12 +10,18 @@
 #' @param ... Other arguments passed down to method.
 #' @export
 #' @examples
+#'
+#' ## Character vector
 #' x <- c("a", "z", "g")
 #' as_factor(x)
 #' as.factor(x)
+#'
+#' ## Character vector containing numbers
 #' y <- c("1.1", "11", "2.2", "22")
 #' as_factor(y)
 #' as.factor(y)
+#'
+#' ## Numeric vector
 #' z <- c(1.1, 11, 2.2, 22)
 #' as_factor(z)
 #' as.factor(z)

--- a/R/as_factor.R
+++ b/R/as_factor.R
@@ -1,8 +1,10 @@
 #' Convert input to a factor.
 #'
-#' Compared to base R, this function creates levels in the order in which
-#' they appear, which will be the same on every platform. (Base R sorts in
-#' the current locale which can vary from place to place.)
+#' Compared to base R, when \code{x} is a character, this function creates
+#' levels in the order in which they appear, which will be the same on every
+#' platform. (Base R sorts in the current locale which can vary from place
+#' to place.) When \code{x} is numeric, the ordering is based on the numeric
+#' value and consistent with base R.
 #'
 #' This is a generic function.
 #'

--- a/R/as_factor.R
+++ b/R/as_factor.R
@@ -11,18 +11,18 @@
 #' @export
 #' @examples
 #'
-#' ## Character vector
+#' ## Character object
 #' x <- c("a", "z", "g")
 #' as_factor(x)
 #' as.factor(x)
 #'
-#' ## Character vector containing numbers
+#' ## Character object containing numbers
 #' y <- c("1.1", "11", "2.2", "22")
 #' as_factor(y)
 #' as.factor(y)
 #'
-#' ## Numeric vector
-#' z <- as_numeric(y)
+#' ## Numeric object
+#' z <- as.numeric(y)
 #' as_factor(z)
 #' as.factor(z)
 as_factor <- function(x, ...) {

--- a/man/as_factor.Rd
+++ b/man/as_factor.Rd
@@ -29,10 +29,19 @@ the current locale which can vary from place to place.)
 This is a generic function.
 }
 \examples{
+
+## Character object
 x <- c("a", "z", "g")
 as_factor(x)
 as.factor(x)
+
+## Character object containing numbers
 y <- c("1.1", "11", "2.2", "22")
 as_factor(y)
 as.factor(y)
+
+## Numeric object
+z <- as.numeric(y)
+as_factor(z)
+as.factor(z)
 }

--- a/man/as_factor.Rd
+++ b/man/as_factor.Rd
@@ -21,9 +21,11 @@ as_factor(x, ...)
 \item{...}{Other arguments passed down to method.}
 }
 \description{
-Compared to base R, this function creates levels in the order in which
-they appear, which will be the same on every platform. (Base R sorts in
-the current locale which can vary from place to place.)
+Compared to base R, when \code{x} is a character, this function creates
+levels in the order in which they appear, which will be the same on every
+platform. (Base R sorts in the current locale which can vary from place
+to place.) When \code{x} is numeric, the ordering is based on the numeric
+value and consistent with base R.
 }
 \details{
 This is a generic function.

--- a/man/as_factor.Rd
+++ b/man/as_factor.Rd
@@ -31,18 +31,17 @@ value and consistent with base R.
 This is a generic function.
 }
 \examples{
-
-## Character object
+# Character object
 x <- c("a", "z", "g")
 as_factor(x)
 as.factor(x)
 
-## Character object containing numbers
+# Character object containing numbers
 y <- c("1.1", "11", "2.2", "22")
 as_factor(y)
 as.factor(y)
 
-## Numeric object
+# Numeric object
 z <- as.numeric(y)
 as_factor(z)
 as.factor(z)


### PR DESCRIPTION
1. Added a third example to `as_factor()` that shows the behaviour with a numeric vector. 

```
y <- c("1.1", "11", "2.2", "22")
z <- as_numeric(y)
as_factor(z)
as.factor(z)
```

Example copied from https://github.com/tidyverse/tidyverse.org/blob/a117fc4fb543f89282a0f8edb38a8fd5d59b8b90/content/articles/2019-05-forcats-0-4-0.Rmarkdown#L73-L78. 

2. Added short descriptions to each example.

~3. Updated `NEWS.md`.~

4. Limited current function description _"creates levels in the order in which they appear"_ to characters and clarified behaviour with numerics (#170) (_"When x is numeric, the ordering is based on the numeric value and consistent with base R."_).

Closes #198. 