### PR TITLE
Correct order for when `group_other = TRUE`

### DIFF
--- a/R/collapse.R
+++ b/R/collapse.R
@@ -23,10 +23,10 @@ fct_collapse <- function(.f, ..., group_other = FALSE) {
     f <- check_factor(.f)
     levels <- levels(f)
     new[["Other"]] <- levels[!levels %in% levs]
-    levs <- levels
+    levs <- purrr::flatten(new)
   }
 
-  names(levs) <- names(new)[rep(seq_along(new), vapply(new, length, integer(1)))]
+  names(levs) <- names(new)
 
   fct_recode(.f, !!!levs)
 }

--- a/R/collapse.R
+++ b/R/collapse.R
@@ -19,7 +19,7 @@
 fct_collapse <- function(.f, ..., group_other = FALSE) {
   new <- rlang::dots_list(...)
   levs <- as.list(unlist(new, use.names = FALSE))
-  if (group_other){
+  if (group_other) {
     f <- check_factor(.f)
     levels <- levels(f)
     new[["Other"]] <- levels[!levels %in% levs]
@@ -28,5 +28,12 @@ fct_collapse <- function(.f, ..., group_other = FALSE) {
 
   names(levs) <- names(new)[rep(seq_along(new), vapply(new, length, integer(1)))]
 
-  fct_recode(.f, !!!levs)
+  f <- fct_recode(.f, !!!levs)
+
+  # if group_other, moves "Other" to last position
+  if (group_other) {
+    fct_relevel(f, "Other", after = Inf)
+  } else {
+    f
+  }
 }

--- a/R/collapse.R
+++ b/R/collapse.R
@@ -26,7 +26,7 @@ fct_collapse <- function(.f, ..., group_other = FALSE) {
     levs <- purrr::flatten(new)
   }
 
-  names(levs) <- names(new)
+  names(levs) <- names(new)[rep(seq_along(new), vapply(new, length, integer(1)))]
 
   fct_recode(.f, !!!levs)
 }


### PR DESCRIPTION
Correct order for when `group_other = TRUE` in `fct_collapse()`. Reorders underlying factor levels before naming them. 

* Fixes #202

With this branch:
``` r
library(tidyverse)

fct_count(gss_cat$partyid)
#> # A tibble: 10 x 2
#>    f                      n
#>    <fct>              <int>
#>  1 No answer            154
#>  2 Don't know             1
#>  3 Other party          393
#>  4 Strong republican   2314
#>  5 Not str republican  3032
#>  6 Ind,near rep        1791
#>  7 Independent         4119
#>  8 Ind,near dem        2499
#>  9 Not str democrat    3690
#> 10 Strong democrat     3490

partyid2 <- fct_collapse(gss_cat$partyid,
                         missing = c("No answer", "Don't know"),
                         rep = c("Strong republican", "Not str republican"),
                         ind = c("Ind,near rep", "Independent", "Ind,near dem"),
                         dem = c("Not str democrat", "Strong democrat"),
                         group_other = TRUE
)


fct_count(partyid2)
#> # A tibble: 5 x 2
#>   f           n
#>   <fct>   <int>
#> 1 missing   155
#> 2 Other     393
#> 3 rep      5346
#> 4 ind      8409
#> 5 dem      7180
```

<sup>Created on 2019-08-14 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>