### PR TITLE
Fix multiple factors issue

### DIFF
--- a/R/fct_cross.R
+++ b/R/fct_cross.R
@@ -2,8 +2,7 @@
 #'
 #' Computes a factor whose levels are all the combinations of the levels of the input factors.
 #'
-#' @param .f A factor or character vector
-#' @param ...  Additional factors or character vectors
+#' @param ...  Any number of factors or character vectors
 #' @param sep A character string to separate the levels
 #' @param keep_empty If TRUE, keep combinations with no observations as levels
 #' @return The new factor
@@ -16,16 +15,14 @@
 #' fct_cross(fruit, colour)
 #' fct_cross(fruit, colour, eaten)
 #' fct_cross(fruit, colour, keep_empty = TRUE)
-fct_cross <- function(.f, ..., sep = ":", keep_empty = FALSE) {
-  .f <- check_factor(.f)
+fct_cross <- function(..., sep = ":", keep_empty = FALSE) {
 
   flist <- rlang::list2(...)
   if (length(flist) == 0) {
-    return(.f)
+    return(NULL)
   }
 
-  .data <- suppressMessages(tibble::tibble(.f, !!!flist, .name_repair = "universal"))
-  .data <- lapply(.data, check_factor)
+  .data <- lapply(flist, check_factor)
   newf <- rlang::invoke(paste, .data, sep = sep)
 
   if (keep_empty) {

--- a/R/fct_cross.R
+++ b/R/fct_cross.R
@@ -24,7 +24,8 @@ fct_cross <- function(.f, ..., sep = ":", keep_empty = FALSE) {
     return(.f)
   }
 
-  .data <- lapply(tibble::tibble(.f, !!!flist), check_factor)
+  .data <- suppressWarnings(tibble::tibble(.f, !!!flist, .name_repair = "universal"))
+  .data <- lapply(.data, check_factor)
   newf <- rlang::invoke(paste, .data, sep = sep)
 
   if (keep_empty) {

--- a/R/fct_cross.R
+++ b/R/fct_cross.R
@@ -24,7 +24,7 @@ fct_cross <- function(.f, ..., sep = ":", keep_empty = FALSE) {
     return(.f)
   }
 
-  .data <- suppressWarnings(tibble::tibble(.f, !!!flist, .name_repair = "universal"))
+  .data <- suppressMessages(tibble::tibble(.f, !!!flist, .name_repair = "universal"))
   .data <- lapply(.data, check_factor)
   newf <- rlang::invoke(paste, .data, sep = sep)
 

--- a/R/fct_cross.R
+++ b/R/fct_cross.R
@@ -16,13 +16,14 @@
 #' fct_cross(fruit, colour, eaten)
 #' fct_cross(fruit, colour, keep_empty = TRUE)
 fct_cross <- function(..., sep = ":", keep_empty = FALSE) {
-
   flist <- rlang::list2(...)
   if (length(flist) == 0) {
-    return(NULL)
+    return(factor())
   }
 
-  .data <- lapply(flist, check_factor)
+  # Hack to recycle vectors to correct length
+  .data <- tibble::as_tibble(flist, .name_repair = "minimal")
+  .data <- lapply(.data, check_factor)
   newf <- rlang::invoke(paste, .data, sep = sep)
 
   if (keep_empty) {

--- a/man/fct_cross.Rd
+++ b/man/fct_cross.Rd
@@ -4,12 +4,10 @@
 \alias{fct_cross}
 \title{Combine levels from two or more factors to create a new factor}
 \usage{
-fct_cross(.f, ..., sep = ":", keep_empty = FALSE)
+fct_cross(..., sep = ":", keep_empty = FALSE)
 }
 \arguments{
-\item{.f}{A factor or character vector}
-
-\item{...}{Additional factors or character vectors}
+\item{...}{Any number of factors or character vectors}
 
 \item{sep}{A character string to separate the levels}
 

--- a/tests/testthat/test-fct_cross.R
+++ b/tests/testthat/test-fct_cross.R
@@ -1,11 +1,20 @@
 context("fct_cross")
 
+test_that("empty input returns empty factor", {
+  expect_equal(fct_cross(), factor())
+})
+
 test_that("gives correct levels", {
   fruit <- as_factor(c("apple", "kiwi", "apple", "apple"))
   colour <- as_factor(c("green", "green", "red", "green"))
   f2 <- fct_cross(fruit, colour)
 
   expect_setequal(levels(f2), c("apple:green", "kiwi:green", "apple:red"))
+})
+
+test_that("recycle inputs", {
+  expect_length(fct_cross("a", c("a", "b", "c"), "d"), 3)
+  expect_error(fct_cross(c("a", "b", "c"), c("a", "b")), "recycle", class = "error")
 })
 
 test_that("keeps empty levels when requested", {

--- a/tests/testthat/test-fct_cross.R
+++ b/tests/testthat/test-fct_cross.R
@@ -34,3 +34,13 @@ test_that("gives NA output on NA input, when keeping empty levels", {
 
   expect_true(is.na(f2[1]))
 })
+
+test_that("can combine more than two factors", {
+  fruit <- as_factor(c("apple", "kiwi", "apple", "apple"))
+  colour <- as_factor(c("green", "green", "red", "green"))
+  eaten <- c("yes", "no", "yes", "no")
+
+  f2 <- fct_cross(fruit, colour, eaten)
+
+  expect_setequal(levels(f2), c("apple:green:no", "apple:green:yes", "apple:red:yes", "kiwi:green:no"))
+})


### PR DESCRIPTION
`fct_cross` was breaking with more than one additional factor, because the default variable name for `tibble::tibble()` is "<fct>", and so there were duplicate variable names.  I've added the option `.name_repair` to take care of this, and suppressed the resulting message.

Addresses #182 