### PR TITLE
Fct_cross level ordering

### DIFF
--- a/R/fct_cross.R
+++ b/R/fct_cross.R
@@ -16,7 +16,7 @@
 #' fct_cross(fruit, colour)
 #' fct_cross(fruit, colour, eaten)
 #' fct_cross(fruit, colour, keep_empty = TRUE)
-fct_cross <- function(.f, ..., sep = ":", keep_empty = FALSE) {
+fct_cross <- function(.f, ..., sep = ":", keep_empty = FALSE, preserve_orders = FALSE) {
   .f <- check_factor(.f)
 
   flist <- rlang::list2(...)
@@ -33,6 +33,13 @@ fct_cross <- function(.f, ..., sep = ":", keep_empty = FALSE) {
       rlang::invoke(expand.grid, all_levels),
       sep = sep
     ))
+  } else if (preserve_orders) {
+    all_levels <- lapply(.data, levels)
+    all_new_levels <- rlang::invoke(paste,
+                                    rlang::invoke(expand.grid, all_levels),
+                                    sep = sep)
+    existing_levels <- all_new_levels[all_new_levels %in% newf]
+    factor(newf, levels = existing_levels)
   } else {
     anyNA <- Reduce("|", lapply(.data, is.na), FALSE)
     newf[anyNA] <- NA

--- a/tests/testthat/test-fct_cross.R
+++ b/tests/testthat/test-fct_cross.R
@@ -16,6 +16,18 @@ test_that("keeps empty levels when requested", {
   expect_setequal(levels(f2), c("apple:green", "kiwi:green", "apple:red", "kiwi:red"))
 })
 
+
+test_that("preserves level orders when requested", {
+  fruit <- as_factor(c("apple", "kiwi", "apple", "apple"))
+  colour <- as_factor(c("green", "green", "red", "green"))
+
+  colour <- factor(colour, levels = c("red", "green"))
+
+  f2 <- fct_cross(fruit, colour, preserve_orders = TRUE)
+
+  expect_setequal(levels(f2), c("apple:red", "apple:green", "kiwi:green"))
+})
+
 test_that("gives NA output on NA input", {
   fruit <- as_factor(c("apple", "kiwi", "apple", "apple"))
   colour <- as_factor(c("green", "green", "red", "green"))


### PR DESCRIPTION
Addresses #183 and #225 

Added the option `preserve_orders` to  `fct_cross`, for when you want the cross-product levels to respect the original level ordering instead of refactoring to alphabetical order.

For example (and also a common use case):

``` r
library(forcats)

f1 <- c("Fall", "Fall", "Winter", "Spring")
f2 <- c("2019", "2018", "2018", "2018")

f1 <- factor(f1, levels = c("Fall", "Winter", "Spring"))

fct_cross(f1, f2)
#> [1] Fall:2019   Fall:2018   Winter:2018 Spring:2018
#> Levels: Fall:2018 Fall:2019 Spring:2018 Winter:2018

fct_cross(f1, f2, preserve_orders = TRUE)
#> [1] Fall:2019   Fall:2018   Winter:2018 Spring:2018
#> Levels: Fall:2018 Winter:2018 Spring:2018 Fall:2019
```

<sup>Created on 2019-12-19 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>



It's my opinion that the ordering should be respected by default.  However, I've left the default to as `preserve_orders = FALSE` for the time being, for backwards compatibility reasons.  

