### PR TITLE
Move NEWS item due to being under wrong version

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,8 @@
 # forcats (development version)
 
 * `first2()`, a `fct_reorder2()` helper function, sorts `.y` by the first value of `.x` (@jtr13).
+  
+* fixed bug in `fct_collapse()` so it now correctly collapses factors when `group_other = TRUE` (#172), and makes `"Other"` the last level (#202) (@gtm19, #172 & #202)
 
 # forcats 0.4.0
 
@@ -8,8 +10,6 @@
 
 * `fct_collapse()` gains a `group_other` argument to allow you to group all 
   un-named levels into `"Other"`. (#100, @AmeliaMN)
-  
-* fixed bug in `fct_collapse()` so it now correctly collapses factors when `group_other = TRUE` (#172), and makes `"Other"` the last level (#202) (@gtm19, #172 & #202)
 
 * `fct_cross()` creates a new factor containing the combined levels from two 
   or more input factors, similar to `base::interaction` (@tslumley, #136)


### PR DESCRIPTION
Moving the bullet point referencing #172 and #202, as it was put under 0.4.0 heading by mistake -- it was not part of that release. Raised in issue #219.