### PR TITLE
fct_cross, preserve level orders and allow more than 2 inputs

### DIFF
--- a/tests/testthat/test-fct_cross.R
+++ b/tests/testthat/test-fct_cross.R
@@ -1,5 +1,9 @@
 context("fct_cross")
 
+test_that("empty input returns empty factor", {
+  expect_equal(fct_cross(), factor())
+})
+
 test_that("gives correct levels", {
   fruit <- as_factor(c("apple", "kiwi", "apple", "apple"))
   colour <- as_factor(c("green", "green", "red", "green"))
@@ -8,12 +12,29 @@ test_that("gives correct levels", {
   expect_setequal(levels(f2), c("apple:green", "kiwi:green", "apple:red"))
 })
 
+test_that("recycle inputs", {
+  expect_length(fct_cross("a", c("a", "b", "c"), "d"), 3)
+  expect_error(fct_cross(c("a", "b", "c"), c("a", "b")), "recycle", class = "error")
+})
+
 test_that("keeps empty levels when requested", {
   fruit <- as_factor(c("apple", "kiwi", "apple", "apple"))
   colour <- as_factor(c("green", "green", "red", "green"))
   f2 <- fct_cross(fruit, colour, keep_empty = TRUE)
 
   expect_setequal(levels(f2), c("apple:green", "kiwi:green", "apple:red", "kiwi:red"))
+})
+
+test_that("order of levels is preserved", {
+  fruit <- as_factor(c("apple", "kiwi", "apple", "apple"))
+  colour <- as_factor(c("green", "green", "red", "green"))
+
+  fruit <- fct_relevel(fruit, c("kiwi", "apple"))
+  colour <- fct_relevel(colour, c("red", "green"))
+
+  f2 <- fct_cross(fruit, colour)
+
+  expect_setequal(levels(f2), c("kiwi:green", "apple:red", "apple:green"))
 })
 
 test_that("gives NA output on NA input", {
@@ -33,4 +54,14 @@ test_that("gives NA output on NA input, when keeping empty levels", {
   f2 <- fct_cross(fruit, colour, keep_empty = TRUE)
 
   expect_true(is.na(f2[1]))
+})
+
+test_that("can combine more than two factors", {
+  fruit <- as_factor(c("apple", "kiwi", "apple", "apple"))
+  colour <- as_factor(c("green", "green", "red", "green"))
+  eaten <- c("yes", "no", "yes", "no")
+
+  f2 <- fct_cross(fruit, colour, eaten)
+
+  expect_setequal(levels(f2), c("apple:green:no", "apple:green:yes", "apple:red:yes", "kiwi:green:no"))
 })


### PR DESCRIPTION
No longer fails for more than two inputs to `fct_cross`

Fixes #182 

Crossed factor levels now respect the level orders of the input (prioritized in argument order).

Fixes #183 

