### PR TITLE
Change `as_factor()` to convert ordered factors to plain factors

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # forcats (development version)
 
-* `as_factor()` converts ordered factor into plain factor (@robinson_es).
+* `as_factor()` converts ordered factor into plain factor (@robinson_es, #216).
 
 * `first2()`, a `fct_reorder2()` helper function, sorts `.y` by the first value of `.x` (@jtr13).
   

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # forcats (development version)
 
+* `as_factor()` converts ordered factor into plain factor (@robinson_es).
+
 * `first2()`, a `fct_reorder2()` helper function, sorts `.y` by the first value of `.x` (@jtr13).
   
 * fixed bug in `fct_collapse()` so it now correctly collapses factors when `group_other = TRUE` (#172), and makes `"Other"` the last level (#202) (@gtm19, #172 & #202)

--- a/R/as_factor.R
+++ b/R/as_factor.R
@@ -36,8 +36,8 @@ as_factor <- function(x, ...) {
 as_factor.factor <- function(x, ...) {
   structure(
     x,
-    label = attr(x, "label", exact = TRUE),
     class = "factor",
+    label = attr(x, "label", exact = TRUE),
     levels = attr(x, "levels", exact = TRUE)
   )
 }

--- a/R/as_factor.R
+++ b/R/as_factor.R
@@ -34,7 +34,12 @@ as_factor <- function(x, ...) {
 #' @rdname as_factor
 #' @export
 as_factor.factor <- function(x, ...) {
-  x
+  structure(
+    x,
+    label = attr(x, "label", exact = TRUE),
+    class = "factor",
+    levels = attr(x, "levels", exact = TRUE)
+  )
 }
 
 #' @rdname as_factor

--- a/tests/testthat/test-as_factor.R
+++ b/tests/testthat/test-as_factor.R
@@ -16,3 +16,10 @@ test_that("supports NA (#89)", {
   x <- c("a", "z", "g", NA)
   expect_equal(as_factor(x), fct_inorder(x))
 })
+
+test_that("converts ordered factor into plain factor (#216)", {
+  x <- factor(c("a", "z", "g"), ordered = TRUE)
+  x <- as_factor(x)
+  expect_false(is.ordered(x))
+  expect_equal(attributes(x)$class, "factor")
+})

--- a/tests/testthat/test-as_factor.R
+++ b/tests/testthat/test-as_factor.R
@@ -20,6 +20,5 @@ test_that("supports NA (#89)", {
 test_that("converts ordered factor into plain factor (#216)", {
   x <- factor(c("a", "z", "g"), ordered = TRUE)
   x <- as_factor(x)
-  expect_false(is.ordered(x))
-  expect_equal(attributes(x)$class, "factor")
+  expect_s3_class(as_factor(x), "factor", exact = "TRUE")
 })


### PR DESCRIPTION
Closes #216. 

I used `structure()` as that's what `as_factor.character` uses. Added two tests and a NEWS item as well.