### PR TITLE
Edit in parameters documentation of fct_relevel 

### DIFF
--- a/R/relevel.R
+++ b/R/relevel.R
@@ -10,7 +10,7 @@
 #'   value (which must be a character vector) will be used to relevel the
 #'   function.
 #'
-#'   Any levels not mentioned will be left in existing order, after the
+#'   Any levels not mentioned will be left in their existing order, after the
 #'   explicitly mentioned levels. Supports tidy dots.
 #' @param after Where should the new values be placed?
 #' @export

--- a/man/fct_relevel.Rd
+++ b/man/fct_relevel.Rd
@@ -15,7 +15,7 @@ A function will be called with the current levels, and the return
 value (which must be a character vector) will be used to relevel the
 function.
 
-Any levels not mentioned will be left in existing order, after the
+Any levels not mentioned will be left in their existing order, after the
 explicitly mentioned levels. Supports tidy dots.}
 
 \item{after}{Where should the new values be placed?}


### PR DESCRIPTION
-[x] Proofread title, description, and parameters

I added 'their' to `@param ...` description for clarity. 
Some thoughts on main description: For me, it's confusing that the description says "reorder" because there is a `fct_reorder()` function. If `fct_relevel()` is re-ordering, then what does `fct_reorder()` do? I did notice that the other releveling/reordering function descriptions begin with "reorder", so perhaps it is written this way for consistency. 

"by hand" could also be misleading because it's possible to pass a function to `...` in addition to the main example which uses character levels. 
 
-[x] Proofread comments in examples
-[x] Ensure comment headings used to divide into scannable sections
-[x] Flag examples that seem overly complex for further review
-[x] Switch out mtcars/iris for something more interesting, or a smaller dataset constructed specifically to illustrate one point.

gss_cat was used in the example.

-[x] Review size of example outputs to ensure that you can easily see important rows and cols.
-[x] Datasets should always be tibbles to avoid use of as_tibble() distracting from the main point

Fixes #231 .