### PR TITLE
add simple example to fct_reorder

### DIFF
--- a/R/reorder.R
+++ b/R/reorder.R
@@ -20,6 +20,18 @@
 #' @importFrom stats median
 #' @export
 #' @examples
+#' df <- tibble::tribble(
+#' ~color,     ~a, ~b,
+#' "blue",      1,  2,
+#' "green",     6,  2,
+#' "purple",    3,  3,
+#' "red",       2,  3,
+#' "yellow",    5,  1
+#' )
+#' df$color <- factor(df$color)
+#' fct_reorder(df$color, df$a, min)
+#' fct_reorder2(df$color, df$a, df$b)
+#'
 #' boxplot(Sepal.Width ~ Species, data = iris)
 #' boxplot(Sepal.Width ~ fct_reorder(Species, Sepal.Width), data = iris)
 #' boxplot(Sepal.Width ~ fct_reorder(Species, Sepal.Width, .desc = TRUE), data = iris)

--- a/R/reorder.R
+++ b/R/reorder.R
@@ -21,12 +21,12 @@
 #' @export
 #' @examples
 #' df <- tibble::tribble(
-#' ~color,     ~a, ~b,
-#' "blue",      1,  2,
-#' "green",     6,  2,
-#' "purple",    3,  3,
-#' "red",       2,  3,
-#' "yellow",    5,  1
+#'   ~color,     ~a, ~b,
+#'   "blue",      1,  2,
+#'   "green",     6,  2,
+#'   "purple",    3,  3,
+#'   "red",       2,  3,
+#'   "yellow",    5,  1
 #' )
 #' df$color <- factor(df$color)
 #' fct_reorder(df$color, df$a, min)

--- a/man/fct_reorder.Rd
+++ b/man/fct_reorder.Rd
@@ -40,6 +40,18 @@ a non-position aesthetic. \code{last2()} and \code{first2()} are helpers for \co
 \code{last2()} finds the last value of \code{y} when sorted by \code{x}; \code{first2()} finds the first value.
 }
 \examples{
+df <- tibble::tribble(
+~color,     ~a, ~b,
+"blue",      1,  2,
+"green",     6,  2,
+"purple",    3,  3,
+"red",       2,  3,
+"yellow",    5,  1
+)
+df$color <- factor(df$color)
+fct_reorder(df$color, df$a, min)
+fct_reorder2(df$color, df$a, df$b)
+
 boxplot(Sepal.Width ~ Species, data = iris)
 boxplot(Sepal.Width ~ fct_reorder(Species, Sepal.Width), data = iris)
 boxplot(Sepal.Width ~ fct_reorder(Species, Sepal.Width, .desc = TRUE), data = iris)


### PR DESCRIPTION
Checked help for fct_reorder. Added a simple data frame at the top of the examples using tribble and then simple examples based on that data. Example is direct use of fct_reorder rather than
using inside another call. I find fct_reoder2 a bit hard to understand and my simple example doesn't help. The ggplot example works better and one is not likely to use fct_reorder alone so perhaps I should not have included the fct_reorder2 example.

Fixes #232