### PR TITLE
Fix partial match in `fct_lump_n()`

### DIFF
--- a/R/lump.R
+++ b/R/lump.R
@@ -147,10 +147,10 @@ fct_lump_n <- function(f, n, w = NULL, other_level = "Other",
   }
 
   if (n < 0) {
-    rank <- rank(calcs$count, ties = ties.method)
+    rank <- rank(calcs$count, ties.method = ties.method)
     n <- -n
   } else {
-    rank <- rank(-calcs$count, ties = ties.method)
+    rank <- rank(-calcs$count, ties.method = ties.method)
   }
 
   new_levels <- ifelse(rank <= n, levels(f), other_level)


### PR DESCRIPTION
Closes #276. This PR fixes a partial argument match in `rank()` in `fct_lump_n()`

``` r
library(forcats)

old <- options(warnPartialMatchArgs = TRUE)
on.exit(options(old), add = TRUE)

x <- factor(letters[rpois(100, 5)])
x <- fct_lump_n(x, n = 6)
#> Warning in rank(-calcs$count, ties = ties.method): partial argument match of
#> 'ties' to 'ties.method'
```

<sup>Created on 2020-07-19 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>