### PR TITLE
fct_lump_prop() fix for empty levels

### DIFF
--- a/R/lump.R
+++ b/R/lump.R
@@ -97,6 +97,7 @@ fct_lump_min <- function(f, min, w = NULL, other_level = "Other") {
   }
 
   new_levels <- ifelse(calcs$count >= min, levels(f), other_level)
+  new_levels <- ifelse(is.na(new_levels), other_level, new_levels)
 
   if (other_level %in% new_levels) {
     f <- lvls_revalue(f, new_levels)

--- a/R/lump.R
+++ b/R/lump.R
@@ -121,9 +121,10 @@ fct_lump_prop <- function(f, prop, w = NULL, other_level = "Other") {
     new_levels <- ifelse(prop_n <= -prop, levels(f), other_level)
   } else {
     new_levels <- ifelse(prop_n > prop, levels(f), other_level)
+    new_levels <- ifelse(is.na(new_levels), other_level, new_levels)
   }
 
-  if (prop > 0 && sum(prop_n <= prop) <= 1) {
+  if (prop > 0 && sum(prop_n <= prop, na.rm = TRUE) <= 1) {
     # No lumping needed
     return(f)
   }

--- a/forcats.Rproj
+++ b/forcats.Rproj
@@ -17,6 +17,5 @@ StripTrailingWhitespace: Yes
 
 BuildType: Package
 PackageUseDevtools: Yes
-PackageCleanBeforeInstall: Yes
 PackageInstallArgs: --no-multiarch --with-keep.source
 PackageRoxygenize: rd,collate,namespace


### PR DESCRIPTION
Fixes the issue of `fct_lump_prop()` when there are unused levels. 

```R
# original example--------------------------------
f <- factor(c("a", "a", "b", "c"), levels = c("a", "b", "c", "d"))
fct_lump_prop(f, prop = 0.25)
# [1] a     a     Other Other
# Levels: a Other

fct_lump_prop(f, prop = 0.25, w = rep(1, 4))
#[1] a     a     Other Other
#Levels: a Other

# Hadley's reprex-----------------------------
f <- factor(c("a", "b", "c"), levels = c("a", "b", "c", "d"))
fct_lump_prop(f, prop = 0.02,  w = c(1,1,1))
#[1] a b c
#Levels: a b c d

# also-------------------------------------
fct_lump_min(f, min = 1,  w = c(1,1,1))
# [1] a b c
# Levels: a b c Other

# previous output
# [1] a b c
# Levels: a b c d
```

Closes #292 