### PR TITLE
see also: `fct_explicit_na()` <-> `fct_recode()`

### DIFF
--- a/R/explicit_na.R
+++ b/R/explicit_na.R
@@ -7,6 +7,7 @@
 #' @param na_level Level to use for missing values: this is what `NA`s will be
 #'   changed to.
 #' @export
+#' @seealso [fct_recode()] to remove levels and recode their values to `NA`.
 #' @examples
 #' f1 <- factor(c("a", "a", NA, NA, "a", "b", NA, "c", "a", "c", "b"))
 #' fct_count(f1)
@@ -15,6 +16,10 @@
 #' f2 <- fct_explicit_na(f1)
 #' fct_count(f2)
 #' table(is.na(f2))
+#'
+#' # use fct_recode() for the reverse operation
+#' f3 <- fct_recode(f2, NULL = "(Missing)")
+#' fct_count(f3)
 fct_explicit_na <- function(f, na_level = "(Missing)") {
   f <- check_factor(f)
 

--- a/R/recode.R
+++ b/R/recode.R
@@ -6,6 +6,7 @@
 #'   level. Levels not otherwise mentioned will be left as is. Levels can
 #'   be removed by naming them `NULL`.
 #' @export
+#' @seealso [fct_explicit_na()] to recode `NA` values to a level.
 #' @examples
 #' x <- factor(c("apple", "bear", "banana", "dear"))
 #' fct_recode(x, fruit = "apple", fruit = "banana")
@@ -13,7 +14,7 @@
 #' # If you make a mistake you'll get a warning
 #' fct_recode(x, fruit = "apple", fruit = "bananana")
 #'
-#' # If you name the level NULL it will be removed
+#' # If you name the level NULL it will be removed and its values become NA
 #' fct_recode(x, NULL = "apple", fruit = "banana")
 #'
 #' # Wrap the left hand side in quotes if it contains special variables

--- a/man/fct_explicit_na.Rd
+++ b/man/fct_explicit_na.Rd
@@ -24,4 +24,11 @@ table(is.na(f1))
 f2 <- fct_explicit_na(f1)
 fct_count(f2)
 table(is.na(f2))
+
+# use fct_recode() for the reverse operation
+f3 <- fct_recode(f2, NULL = "(Missing)")
+fct_count(f3)
+}
+\seealso{
+\code{\link[=fct_recode]{fct_recode()}} to remove levels and recode their values to \code{NA}.
 }

--- a/man/fct_recode.Rd
+++ b/man/fct_recode.Rd
@@ -24,7 +24,7 @@ fct_recode(x, fruit = "apple", fruit = "banana")
 # If you make a mistake you'll get a warning
 fct_recode(x, fruit = "apple", fruit = "bananana")
 
-# If you name the level NULL it will be removed
+# If you name the level NULL it will be removed and its values become NA
 fct_recode(x, NULL = "apple", fruit = "banana")
 
 # Wrap the left hand side in quotes if it contains special variables
@@ -34,4 +34,7 @@ fct_recode(x, "an apple" = "apple", "a bear" = "bear")
 x <- factor(c("apple", "bear", "banana", "dear"))
 levels <- c(fruit = "apple", fruit = "banana")
 fct_recode(x, !!!levels)
+}
+\seealso{
+\code{\link[=fct_explicit_na]{fct_explicit_na()}} to recode \code{NA} values to a level.
 }


### PR DESCRIPTION
I spent way too much time to day to find the reverse operation of `fct_explicit_na()`, so I thought it might be helpful to reference `fct_recode()` there and vice versa. I think this might be helpful, but feel free to edit or close if you don't agree, of course.