### PR TITLE
Improved handling of NAs in `fct_reorder()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,12 @@
 # forcats (development version)
 
+* `fct_reorder()` now removes `NA` values in `.x` with a warning (like
+   `ggplot2::geom_point()` and friends). You can suppress the warning by
+   setting `.na_rm = TRUE` (#315).
+   
+* `fct_reorder()` gains a new `.na_last` argument that allows you to control
+  where levels that are empty or only contain missing values are placed (#266).
+
 * `fct_explicit_na()` is deprecated in favour of `fct_na_value_to_level()`.
 
 * New `fct_na_value_to_level()` and `fct_na_level_to_value()` to convert 

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,8 +4,9 @@
    `ggplot2::geom_point()` and friends). You can suppress the warning by
    setting `.na_rm = TRUE` (#315).
    
-* `fct_reorder()` gains a new `.na_last` argument that allows you to control
-  where levels that are empty or only contain missing values are placed (#266).
+* `fct_reorder()` gains a new `.default` argument controls the placement of 
+  empty levels (including levels that might become empty after removing
+  missing values in `.x`) (#266).
 
 * `fct_explicit_na()` is deprecated in favour of `fct_na_value_to_level()`.
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,7 +4,7 @@
    `ggplot2::geom_point()` and friends). You can suppress the warning by
    setting `.na_rm = TRUE` (#315).
    
-* `fct_reorder()` gains a new `.default` argument controls the placement of 
+* `fct_reorder()` gains a new `.default` argument that controls the placement of 
   empty levels (including levels that might become empty after removing
   missing values in `.x`) (#266).
 

--- a/R/reorder.R
+++ b/R/reorder.R
@@ -12,7 +12,7 @@
 #' @param .fun n summary function. It should take one vector for
 #'   `fct_reorder`, and two vectors for `fct_reorder2`, and return a single
 #'   value.
-#' @param .na_rm Should `fct_reorder()` silently remove missing values?
+#' @param .na_rm Should `fct_reorder()` remove missing values?
 #'   If `NULL`, the default, will remove missing values with a warning.
 #'   Set to `FALSE` to preserve `NA`s (if you `.fun` already handles them) and
 #'   `TRUE` to remove silently.

--- a/R/reorder.R
+++ b/R/reorder.R
@@ -14,7 +14,8 @@
 #'   value.
 #' @param .na_rm Should `fct_reorder()` silently remove missing values?
 #'   If `NULL`, the default, will remove missing values with a warning.
-#'   Set to `FALSE` to preserve `NA`s and `TRUE` to remove silently.
+#'   Set to `FALSE` to preserve `NA`s (if you `.fun` already handles them) and
+#'   `TRUE` to remove silently.
 #' @param .default What default value should we use for `.fun` for
 #'   empty levels? Use this to control where empty levels appear in the
 #'   output.
@@ -61,7 +62,8 @@ fct_reorder <- function(.f, .x, .fun = median, ..., .na_rm = NULL, .default = In
     if (is.null(.na_rm)) {
       cli::cli_warn(c(
         "{.fn fct_reorder} removing {sum(miss)} missing value{?s}.",
-        i = "Use `.na_rm = TRUE` to silence this message"
+        i = "Use {.code .na_rm = TRUE} to silence this message.",
+        i = "Use {.code .na_rm = FALSE} to preserve NAs."
       ))
       .na_rm <- TRUE
     }

--- a/man/fct_reorder.Rd
+++ b/man/fct_reorder.Rd
@@ -12,8 +12,8 @@ fct_reorder(
   .x,
   .fun = median,
   ...,
-  .na_rm = FALSE,
-  .na_last = TRUE,
+  .na_rm = NULL,
+  .default = Inf,
   .desc = FALSE
 )
 
@@ -37,11 +37,12 @@ value.}
 \item{...}{Other arguments passed on to \code{.fun}.}
 
 \item{.na_rm}{Should \code{fct_reorder()} silently remove missing values?
-If \code{FALSE}, the default, will remove missing values with a warning.}
+If \code{NULL}, the default, will remove missing values with a warning.
+Set to \code{FALSE} to preserve \code{NA}s and \code{TRUE} to remove silently.}
 
-\item{.na_last}{Should \code{NA} values be ordered last (\code{TRUE}) or first
-(\code{FALSE}). Particularly important for empty levels, since their
-summary result will always be \code{NA}.}
+\item{.default}{What default value should we use for \code{.fun} for
+empty levels? Use this to control where empty levels appear in the
+output.}
 
 \item{.desc}{Order in descending order? Note the default is different
 between \code{fct_reorder} and \code{fct_reorder2}, in order to

--- a/man/fct_reorder.Rd
+++ b/man/fct_reorder.Rd
@@ -7,7 +7,15 @@
 \alias{first2}
 \title{Reorder factor levels by sorting along another variable}
 \usage{
-fct_reorder(.f, .x, .fun = median, ..., .desc = FALSE)
+fct_reorder(
+  .f,
+  .x,
+  .fun = median,
+  ...,
+  .na_rm = FALSE,
+  .na_last = TRUE,
+  .desc = FALSE
+)
 
 fct_reorder2(.f, .x, .y, .fun = last2, ..., .desc = TRUE)
 
@@ -26,8 +34,14 @@ are in ascending order.}
 \code{fct_reorder}, and two vectors for \code{fct_reorder2}, and return a single
 value.}
 
-\item{...}{Other arguments passed on to \code{.fun}. A common argument is
-\code{na.rm = TRUE}.}
+\item{...}{Other arguments passed on to \code{.fun}.}
+
+\item{.na_rm}{Should \code{fct_reorder()} silently remove missing values?
+If \code{FALSE}, the default, will remove missing values with a warning.}
+
+\item{.na_last}{Should \code{NA} values be ordered last (\code{TRUE}) or first
+(\code{FALSE}). Particularly important for empty levels, since their
+summary result will always be \code{NA}.}
 
 \item{.desc}{Order in descending order? Note the default is different
 between \code{fct_reorder} and \code{fct_reorder2}, in order to

--- a/man/fct_reorder.Rd
+++ b/man/fct_reorder.Rd
@@ -36,9 +36,10 @@ value.}
 
 \item{...}{Other arguments passed on to \code{.fun}.}
 
-\item{.na_rm}{Should \code{fct_reorder()} silently remove missing values?
+\item{.na_rm}{Should \code{fct_reorder()} remove missing values?
 If \code{NULL}, the default, will remove missing values with a warning.
-Set to \code{FALSE} to preserve \code{NA}s and \code{TRUE} to remove silently.}
+Set to \code{FALSE} to preserve \code{NA}s (if you \code{.fun} already handles them) and
+\code{TRUE} to remove silently.}
 
 \item{.default}{What default value should we use for \code{.fun} for
 empty levels? Use this to control where empty levels appear in the

--- a/tests/testthat/_snaps/reorder.md
+++ b/tests/testthat/_snaps/reorder.md
@@ -28,7 +28,8 @@
     Condition
       Warning:
       `fct_reorder()` removing 1 missing value.
-      i Use `.na_rm = TRUE` to silence this message
+      i Use `.na_rm = TRUE` to silence this message.
+      i Use `.na_rm = FALSE` to preserve NAs.
 
 # fct_infreq() validates weight
 

--- a/tests/testthat/_snaps/reorder.md
+++ b/tests/testthat/_snaps/reorder.md
@@ -21,6 +21,15 @@
       Error in `fct_reorder2()`:
       ! `.fun` must return a single value per group
 
+# automatically removes missing values with a warning
+
+    Code
+      f2 <- fct_reorder(f1, x)
+    Condition
+      Warning:
+      `fct_reorder()` removing 1 missing value.
+      i Use `.na_rm = TRUE` to silence this message
+
 # fct_infreq() validates weight
 
     Code

--- a/tests/testthat/test-reorder.R
+++ b/tests/testthat/test-reorder.R
@@ -71,6 +71,21 @@ test_that("complains if summary doesn't return single value", {
   })
 })
 
+test_that("automatically removes missing values with a warning", {
+  f1 <- fct(c("a", "b", "c", "c"))
+  x <- c(3, 2, 1, NA)
+
+  expect_snapshot(f2 <- fct_reorder(f1, x))
+  expect_equal(levels(f2), c("c", "b", "a"))
+})
+
+test_that("can control the placement of NA levels", {
+  f1 <- fct(c("a", "b", "c"), letters[1:4])
+  x <- c(1, 2, 3)
+
+  f2 <- fct_reorder(f1, x, .na_last = FALSE)
+  expect_equal(levels(f2), c("d", "a", "b", "c"))
+})
 
 # fct_infreq --------------------------------------------------------------
 

--- a/tests/testthat/test-reorder.R
+++ b/tests/testthat/test-reorder.R
@@ -92,6 +92,14 @@ test_that("can control the placement of empty levels", {
   expect_equal(levels(f2), c("d", "a", "b", "c"))
 })
 
+test_that("can control the placement of levels with all missing data", {
+  f1 <- fct(c("a", "b", "c"))
+  x <- c(1, 2, NA)
+
+  f2 <- fct_reorder(f1, x, .na_rm = TRUE, .default = -Inf)
+  expect_equal(levels(f2), c("c", "a", "b"))
+})
+
 # fct_infreq --------------------------------------------------------------
 
 test_that("fct_infreq() preserves explicit NA", {

--- a/tests/testthat/test-reorder.R
+++ b/tests/testthat/test-reorder.R
@@ -77,13 +77,18 @@ test_that("automatically removes missing values with a warning", {
 
   expect_snapshot(f2 <- fct_reorder(f1, x))
   expect_equal(levels(f2), c("c", "b", "a"))
+
+  expect_no_warning(fct_reorder(f1, x, .na_rm = TRUE))
+
+  expect_no_warning(f3 <- fct_reorder(f1, x, .na_rm = FALSE))
+  expect_equal(levels(f3), c("b", "a", "c"))
 })
 
-test_that("can control the placement of NA levels", {
+test_that("can control the placement of empty levels", {
   f1 <- fct(c("a", "b", "c"), letters[1:4])
   x <- c(1, 2, 3)
 
-  f2 <- fct_reorder(f1, x, .na_last = FALSE)
+  f2 <- fct_reorder(f1, x, .default = -Inf)
   expect_equal(levels(f2), c("d", "a", "b", "c"))
 })
 


### PR DESCRIPTION
* Drop missing values in `.x` by default. Fixes #315.
* New `.na_last` argument to control position of NAs. Fixes #266.

@DavisVaughan what do you think of this API? It's a bit unusual to default to `na.rm = TRUE`, but you can't see the result of the computation and including `NA`s is never useful, so adopting ggplot2's approach makes sense to me. Once you've reviewed this API, I'll also apply it to `fct_reorder2()`.