### PR TITLE
Base R pipe AND lambda notation. Fixes #381

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -39,4 +39,4 @@ Config/testthat/edition: 3
 Encoding: UTF-8
 LazyData: true
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.3.2
+RoxygenNote: 7.3.3

--- a/R/anon.R
+++ b/R/anon.R
@@ -7,12 +7,12 @@
 #' @param prefix A character prefix to insert in front of the random labels.
 #' @export
 #' @examples
-#' gss_cat$relig %>% fct_count()
-#' gss_cat$relig %>%
-#'   fct_anon() %>%
+#' gss_cat$relig |> fct_count()
+#' gss_cat$relig |>
+#'   fct_anon() |>
 #'   fct_count()
-#' gss_cat$relig %>%
-#'   fct_anon("X") %>%
+#' gss_cat$relig |>
+#'   fct_anon("X") |>
 #'   fct_count()
 fct_anon <- function(f, prefix = "") {
   f <- check_factor(f)

--- a/R/lump.R
+++ b/R/lump.R
@@ -32,18 +32,18 @@
 #' @seealso [fct_other()] to convert specified levels to other.
 #' @examples
 #' x <- factor(rep(LETTERS[1:9], times = c(40, 10, 5, 27, 1, 1, 1, 1, 1)))
-#' x %>% table()
-#' x %>%
-#'   fct_lump_n(3) %>%
+#' x |> table()
+#' x |>
+#'   fct_lump_n(3) |>
 #'   table()
-#' x %>%
-#'   fct_lump_prop(0.10) %>%
+#' x |>
+#'   fct_lump_prop(0.10) |>
 #'   table()
-#' x %>%
-#'   fct_lump_min(5) %>%
+#' x |>
+#'   fct_lump_min(5) |>
 #'   table()
-#' x %>%
-#'   fct_lump_lowfreq() %>%
+#' x |>
+#'   fct_lump_lowfreq() |>
 #'   table()
 #'
 #' x <- factor(letters[rpois(100, 5)])

--- a/R/relabel.R
+++ b/R/relabel.R
@@ -5,14 +5,14 @@
 #'   character argument and return a character vector of the same length as
 #'   its input.
 #'
-#'   You can also use `~` to create as shorthand (in the style of purrr).
-#'   `~ paste(., "x")` is equivalent to `function(.) paste(., "x")`
+#'   You can also use lambda notation, `\(x)`.
+#'   `\(x) paste(x, "y")` is equivalent to `function(x) paste(x, "y")` or `function(.) paste(., "y")`.
 #' @param ... Additional arguments to `fun`.
 #' @export
 #' @examples
-#' gss_cat$partyid %>% fct_count()
-#' gss_cat$partyid %>%
-#'   fct_relabel(~ gsub(",", ", ", .x)) %>%
+#' gss_cat$partyid |> fct_count()
+#' gss_cat$partyid |>
+#'   fct_relabel(\(x) gsub(",", ", ", x)) |>
 #'   fct_count()
 #'
 #' convert_income <- function(x) {

--- a/README.Rmd
+++ b/README.Rmd
@@ -60,15 +60,15 @@ library(ggplot2)
 ```
 
 ```{r}
-starwars %>% 
-  filter(!is.na(species)) %>%
+starwars |> 
+  filter(!is.na(species)) |>
   count(species, sort = TRUE)
 ```
 
 ```{r}
-starwars %>%
-  filter(!is.na(species)) %>%
-  mutate(species = fct_lump(species, n = 3)) %>%
+starwars |>
+  filter(!is.na(species)) |>
+  mutate(species = fct_lump(species, n = 3)) |>
   count(species)
 ```
 
@@ -79,8 +79,8 @@ ggplot(starwars, aes(x = eye_color)) +
 ```
 
 ```{r ordered-plot}
-starwars %>%
-  mutate(eye_color = fct_infreq(eye_color)) %>%
+starwars |>
+  mutate(eye_color = fct_infreq(eye_color)) |>
   ggplot(aes(x = eye_color)) + 
   geom_bar() + 
   coord_flip()

--- a/README.md
+++ b/README.md
@@ -59,8 +59,8 @@ library(ggplot2)
 ```
 
 ``` r
-starwars %>% 
-  filter(!is.na(species)) %>%
+starwars |> 
+  filter(!is.na(species)) |>
   count(species, sort = TRUE)
 #> # A tibble: 37 × 2
 #>    species      n
@@ -79,9 +79,9 @@ starwars %>%
 ```
 
 ``` r
-starwars %>%
-  filter(!is.na(species)) %>%
-  mutate(species = fct_lump(species, n = 3)) %>%
+starwars |>
+  filter(!is.na(species)) |>
+  mutate(species = fct_lump(species, n = 3)) |>
   count(species)
 #> # A tibble: 4 × 2
 #>   species     n
@@ -101,8 +101,8 @@ ggplot(starwars, aes(x = eye_color)) +
 ![](man/figures/README-unordered-plot-1.png)<!-- -->
 
 ``` r
-starwars %>%
-  mutate(eye_color = fct_infreq(eye_color)) %>%
+starwars |>
+  mutate(eye_color = fct_infreq(eye_color)) |>
   ggplot(aes(x = eye_color)) + 
   geom_bar() + 
   coord_flip()

--- a/data-raw/gss-cat.R
+++ b/data-raw/gss-cat.R
@@ -13,9 +13,9 @@ names(gss) <- vars$Name
 
 na <- c("Not applicable", "No answer", "Don't know")
 
-gss_cat <- gss %>%
-  filter(!is.na(id_)) %>%
-  select(-id_) %>%
+gss_cat <- gss |>
+  filter(!is.na(id_)) |>
+  select(-id_) |>
   mutate(
     year = as.integer(year),
     age = as.integer(readr::parse_number(age, na = na)), # ignore 148 "or older"

--- a/man/fct_anon.Rd
+++ b/man/fct_anon.Rd
@@ -16,11 +16,11 @@ Replaces factor levels with arbitrary numeric identifiers. Neither
 the values nor the order of the levels are preserved.
 }
 \examples{
-gss_cat$relig \%>\% fct_count()
-gss_cat$relig \%>\%
-  fct_anon() \%>\%
+gss_cat$relig |> fct_count()
+gss_cat$relig |>
+  fct_anon() |>
   fct_count()
-gss_cat$relig \%>\%
-  fct_anon("X") \%>\%
+gss_cat$relig |>
+  fct_anon("X") |>
   fct_count()
 }

--- a/man/fct_lump.Rd
+++ b/man/fct_lump.Rd
@@ -71,18 +71,18 @@ We no longer recommend that you use it.
 }
 \examples{
 x <- factor(rep(LETTERS[1:9], times = c(40, 10, 5, 27, 1, 1, 1, 1, 1)))
-x \%>\% table()
-x \%>\%
-  fct_lump_n(3) \%>\%
+x |> table()
+x |>
+  fct_lump_n(3) |>
   table()
-x \%>\%
-  fct_lump_prop(0.10) \%>\%
+x |>
+  fct_lump_prop(0.10) |>
   table()
-x \%>\%
-  fct_lump_min(5) \%>\%
+x |>
+  fct_lump_min(5) |>
   table()
-x \%>\%
-  fct_lump_lowfreq() \%>\%
+x |>
+  fct_lump_lowfreq() |>
   table()
 
 x <- factor(letters[rpois(100, 5)])

--- a/man/fct_relabel.Rd
+++ b/man/fct_relabel.Rd
@@ -13,8 +13,8 @@ fct_relabel(.f, .fun, ...)
 character argument and return a character vector of the same length as
 its input.
 
-You can also use \code{~} to create as shorthand (in the style of purrr).
-\code{~ paste(., "x")} is equivalent to \code{function(.) paste(., "x")}}
+You can also use lambda notation, \verb{\\(x)}.
+\verb{\\(x) paste(x, "y")} is equivalent to \code{function(x) paste(x, "y")} or \code{function(.) paste(., "y")}.}
 
 \item{...}{Additional arguments to \code{fun}.}
 }
@@ -22,9 +22,9 @@ You can also use \code{~} to create as shorthand (in the style of purrr).
 Relabel factor levels with a function, collapsing as necessary
 }
 \examples{
-gss_cat$partyid \%>\% fct_count()
-gss_cat$partyid \%>\%
-  fct_relabel(~ gsub(",", ", ", .x)) \%>\%
+gss_cat$partyid |> fct_count()
+gss_cat$partyid |>
+  fct_relabel(\(x) gsub(",", ", ", x)) |>
   fct_count()
 
 convert_income <- function(x) {

--- a/man/forcats-package.Rd
+++ b/man/forcats-package.Rd
@@ -24,7 +24,7 @@ Useful links:
 
 Other contributors:
 \itemize{
-  \item Posit Software, PBC (03wc8by49) [copyright holder, funder]
+  \item Posit Software, PBC (\href{https://ror.org/03wc8by49}{ROR}) [copyright holder, funder]
 }
 
 }

--- a/vignettes/forcats.Rmd
+++ b/vignettes/forcats.Rmd
@@ -103,7 +103,7 @@ ggplot(starwars, aes(y = fct_infreq(fct_na_value_to_level(hair_color)))) +
 Let's take a look at skin color now:
 
 ```{r}
-starwars %>%
+starwars |>
   count(skin_color, sort = TRUE)
 ```
 
@@ -112,8 +112,8 @@ Let's reduce it to only be the top 5.
 We can use `fct_lump()` to "lump" all the infrequent colors into one factor, "other." The argument `n` is the number of levels we want to keep.
 
 ```{r}
-starwars %>%
-  mutate(skin_color = fct_lump(skin_color, n = 5)) %>%
+starwars |>
+  mutate(skin_color = fct_lump(skin_color, n = 5)) |>
   count(skin_color, sort = TRUE)
 ```
 
@@ -121,8 +121,8 @@ We could also have used `prop` instead, which keeps all the levels that appear a
 For example, let's keep skin colors that at least 10% of the characters have:
 
 ```{r}
-starwars %>%
-  mutate(skin_color = fct_lump(skin_color, prop = .1)) %>%
+starwars |>
+  mutate(skin_color = fct_lump(skin_color, prop = .1)) |>
   count(skin_color, sort = TRUE)
 ```
 
@@ -131,8 +131,8 @@ Only light and fair remain; everything else is other.
 If you wanted to call it something than "other", you can change it with the argument `other_level`:
 
 ```{r}
-starwars %>%
-  mutate(skin_color = fct_lump(skin_color, prop = .1, other_level = "extra")) %>%
+starwars |>
+  mutate(skin_color = fct_lump(skin_color, prop = .1, other_level = "extra")) |>
   count(skin_color, sort = TRUE)
 ```
 
@@ -140,9 +140,9 @@ What if we wanted to see if the average mass differed by eye color?
 We'll only look at the 6 most popular eye colors and remove `NA`s.
 
 ```{r fct-lump-mean}
-avg_mass_eye_color <- starwars %>%
-  mutate(eye_color = fct_lump(eye_color, n = 6)) %>%
-  group_by(eye_color) %>%
+avg_mass_eye_color <- starwars |>
+  mutate(eye_color = fct_lump(eye_color, n = 6)) |>
+  group_by(eye_color) |>
   summarise(mean_mass = mean(mass, na.rm = TRUE))
 
 avg_mass_eye_color
@@ -160,8 +160,8 @@ We can do this with `fct_reorder()`, which reorders one variable by another.
 #|   y-axis. The bars are ordered by mean_mass, so that the tallest bar
 #|   (orange eye color with mean mass of ~275) is at the far right.
 
-avg_mass_eye_color %>%
-  mutate(eye_color = fct_reorder(eye_color, mean_mass)) %>%
+avg_mass_eye_color |>
+  mutate(eye_color = fct_reorder(eye_color, mean_mass)) |>
   ggplot(aes(x = eye_color, y = mean_mass)) + 
   geom_col()
 ```
@@ -172,7 +172,7 @@ Let's switch to using another dataset, `gss_cat`, the general social survey.
 What is the income distribution among the respondents?
 
 ```{r}
-gss_cat %>%
+gss_cat |>
   count(rincome)
 ```
 
@@ -190,7 +190,7 @@ But what if your factor came in the wrong order?
 Let's simulate that by reordering the levels of `rincome` randomly with `fct_shuffle()`:
 
 ```{r}
-reshuffled_income <- gss_cat$rincome %>%
+reshuffled_income <- gss_cat$rincome |>
   fct_shuffle()
 
 levels(reshuffled_income)
@@ -208,13 +208,13 @@ For example, let's say we wanted to move `Lt $1000` and `$1000 to 2999` to the f
 We would write:
 
 ```{r}
-fct_relevel(reshuffled_income, c("Lt $1000", "$1000 to 2999")) %>%
+fct_relevel(reshuffled_income, c("Lt $1000", "$1000 to 2999")) |>
   levels()
 ```
 
 What if we want to move them to the second and third place?
 
 ```{r}
-fct_relevel(reshuffled_income, c("Lt $1000", "$1000 to 2999"), after = 1) %>%
+fct_relevel(reshuffled_income, c("Lt $1000", "$1000 to 2999"), after = 1) |>
   levels()
 ```


### PR DESCRIPTION
Searched all `*.R` and `.Rmd` files for examples using `magrittr` pipe, `%>%`. No examples needed, e.g.,
```
y |> (\(x) f(a = x, b = x))()
```
nor
```
y |> f(second_arg = _)
```
etc.

Finally, issue mentions that `fct_relevel` needs changes, but it doesn't.

P.S., I did this at tidy dev day _and_ I am seeing that Gabor already submitted an issue that handles the pipe but NOT the formula vs lambda notation. FWIW, there _is_ an example using `~`, but it's a formula in `boxplot`. 